### PR TITLE
Fix Promise argument not being used in promisifyStripe()

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,5 @@ module.exports = function promisifyStripe (Stripe, Promise) {
   if (typeof Promise !== 'function') throw new Error('Promise constructor must be provided')
 
   var stripe = stripeErrback(Stripe)
-  return promisify(stripe)
+  return promisify(stripe, Promise)
 }


### PR DESCRIPTION
The passed in `Promise` constructor is not used. This becomes a problem if `Promise` is not defined (i.e. on IE without a Promise polyfill).